### PR TITLE
Merge default middlewares with user-provided stack, if it's given.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -82,8 +82,9 @@ class Client
             ];
         }
 
+        // Append to Handler Stack given, or create a new one.
+        $HandlerStack = $guzzleOptions['handler'] ?? GuzzleHttp\HandlerStack::create();
         // Setup logging bit
-        $HandlerStack = GuzzleHttp\HandlerStack::create();
         $HandlerStack->push(
             GuzzleHttp\Middleware::log(
                 Logger::getInstance()->getLogger(),


### PR DESCRIPTION
When constructing the client, our business rules dictate that we use custom middleware to manipulate authorization headers. As a result, the `array_merge()` in the client constructor uses our provided handler stack instead of this library's defaults. This means we don't get the benefit of the `setPatchOperationContentType` middleware.

This patch appends to the user's handler stack, if provided. Otherwise it preserves the existing behaviour (merging this key into the options array.)